### PR TITLE
Update base.txt for updated versions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,6 @@ kombu==4.6.1
 pytz==2019.1
 redis==3.2.1
 vine==1.3.0
-opentelemetry-distro==0.28b0
-opentelemetry-instrumentation==0.28b0
-opentelemetry-exporter-otlp==1.9.0
+opentelemetry-instrumentation==0.39b0
+opentelemetry-distro==0.39b0
+opentelemetry-exporter-otlp==1.18.0


### PR DESCRIPTION
app service not showing on staging URL, plus generated these errors 

I last instrumented these app half an year ago and the app worked fine with no errors but even last time could not get traces on signoz dashboard. 

followed this blog - https://signoz.io/blog/opentelemetry-falcon/

base.txt file
```
amqp==2.5.0
billiard==3.6.0.0
celery==4.3.0
Cython==0.29.27
falcon==2.0.0
falcon-cors==1.1.7
gunicorn==19.9.0
kombu==4.6.1
pytz==2019.1
redis==3.2.1
vine==1.3.0
opentelemetry-instrumentation==0.39b0
opentelemetry-distro==0.39b0
opentelemetry-exporter-otlp==1.18.0
```


```
Requirement already satisfied: importlib-metadata~=6.0.0 in /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages (from opentelemetry-api~=1.12->opentelemetry-instrumentation-asgi==0.39b0) (6.0.1)
Requirement already satisfied: zipp>=0.5 in /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages (from importlib-metadata~=6.0.0->opentelemetry-api~=1.12->opentelemetry-instrumentation-asgi==0.39b0) (3.16.0)
Installing collected packages: opentelemetry-instrumentation-asgi
  Attempting uninstall: opentelemetry-instrumentation-asgi
    Found existing installation: opentelemetry-instrumentation-asgi 0.29b0
    Uninstalling opentelemetry-instrumentation-asgi-0.29b0:
      Successfully uninstalled opentelemetry-instrumentation-asgi-0.29b0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-instrumentation-asgi==0.29b0, but you have opentelemetry-instrumentation-asgi 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
Successfully installed opentelemetry-instrumentation-asgi-0.39b0

```

```
Requirement already satisfied: zipp>=0.5 in /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages (from importlib-metadata~=6.0.0->opentelemetry-api~=1.12->opentelemetry-instrumentation-wsgi==0.39b0) (3.16.0)
Installing collected packages: opentelemetry-instrumentation-wsgi
  Attempting uninstall: opentelemetry-instrumentation-wsgi
    Found existing installation: opentelemetry-instrumentation-wsgi 0.29b0
    Uninstalling opentelemetry-instrumentation-wsgi-0.29b0:
      Successfully uninstalled opentelemetry-instrumentation-wsgi-0.29b0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-instrumentation-wsgi==0.29b0, but you have opentelemetry-instrumentation-wsgi 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-instrumentation-wsgi==0.29b0, but you have opentelemetry-instrumentation-wsgi 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
Successfully installed opentelemetry-instrumentation-wsgi-0.39b0

```

```
Installing collected packages: opentelemetry-util-http, opentelemetry-instrumentation-urllib
  Attempting uninstall: opentelemetry-util-http
    Found existing installation: opentelemetry-util-http 0.29b0
    Uninstalling opentelemetry-util-http-0.29b0:
      Successfully uninstalled opentelemetry-util-http-0.29b0
  Attempting uninstall: opentelemetry-instrumentation-urllib
    Found existing installation: opentelemetry-instrumentation-urllib 0.29b0
    Uninstalling opentelemetry-instrumentation-urllib-0.29b0:
      Successfully uninstalled opentelemetry-instrumentation-urllib-0.29b0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
opentelemetry-instrumentation-wsgi 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-wsgi 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-wsgi 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-urllib3 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-urllib3 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-urllib3 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-requests 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-requests 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-requests 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-flask 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-fastapi 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-django 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-asgi 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-asgi 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-asgi 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
opentelemetry-instrumentation-aiohttp-client 0.29b0 requires opentelemetry-instrumentation==0.29b0, but you have opentelemetry-instrumentation 0.39b0 which is incompatible.
opentelemetry-instrumentation-aiohttp-client 0.29b0 requires opentelemetry-semantic-conventions==0.29b0, but you have opentelemetry-semantic-conventions 0.39b0 which is incompatible.
opentelemetry-instrumentation-aiohttp-client 0.29b0 requires opentelemetry-util-http==0.29b0, but you have opentelemetry-util-http 0.39b0 which is incompatible.
Successfully installed opentelemetry-instrumentation-urllib-0.39b0 opentelemetry-util-http-0.39b0

```